### PR TITLE
fix: add feature.properties to binary huild to have it resolved

### DIFF
--- a/com.aobuchow.sample.commander.feature/build.properties
+++ b/com.aobuchow.sample.commander.feature/build.properties
@@ -1,1 +1,2 @@
-bin.includes = feature.xml
+bin.includes = feature.xml,\
+               feature.properties


### PR DESCRIPTION
Fixed problem with ``feature.properties`` not included in binary build and, thus, not being resolved.

#### Manual Integration Test
Now, the feature name is displayed at installing the feature.
And so is the license.